### PR TITLE
Feat/collective actions members

### DIFF
--- a/app/src/main/java/io/github/sustainow/di/RepositoryModule.kt
+++ b/app/src/main/java/io/github/sustainow/di/RepositoryModule.kt
@@ -32,7 +32,11 @@ object RepositoryModule {
     fun provideCollectiveActionRepository(context: Context, supabaseClient: SupabaseClient): CollectiveActionRepository{
         return CollectiveActionRepositorySupabaseImp(
             supabaseClient,
-            tableName = "action",
+            actionTableName = "action",
+            invitationTableName = "action_invitation",
+            memberTableName = "action_member",
+            memberActivityTableName = "action_member_activity",
+            usernameTableName = "user_name",
             context
         )
     }

--- a/app/src/main/java/io/github/sustainow/di/ServiceModule.kt
+++ b/app/src/main/java/io/github/sustainow/di/ServiceModule.kt
@@ -58,7 +58,7 @@ object ServiceModule {
 
     @Provides
     @Singleton
-    fun provideAuthRepository(auth: Auth): AuthService {
-        return AuthServiceSupabaseImp(auth)
+    fun provideAuthRepository(auth: Auth, client: SupabaseClient): AuthService {
+        return AuthServiceSupabaseImp(supabase = client,auth=auth)
     }
 }

--- a/app/src/main/java/io/github/sustainow/domain/model/CollectiveAction.kt
+++ b/app/src/main/java/io/github/sustainow/domain/model/CollectiveAction.kt
@@ -2,17 +2,18 @@ package io.github.sustainow.domain.model
 
 import android.net.Uri
 import kotlinx.datetime.LocalDate
+import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
-data class CollectiveAction(
+data class CollectiveAction @OptIn(ExperimentalUuidApi::class) constructor(
     val id: Int?,
     var images:List<Uri>,
     val name: String,
     val description:String,
-    // TODO use uuid
-    val authorId: String,
+    val authorId: Uuid,
     val authorName:String?,
     val startDate:LocalDate,
     val endDate:LocalDate,
     val status:String,
+    val members: List<UserProfile>
 )

--- a/app/src/main/java/io/github/sustainow/domain/model/Invitation.kt
+++ b/app/src/main/java/io/github/sustainow/domain/model/Invitation.kt
@@ -1,0 +1,9 @@
+package io.github.sustainow.domain.model
+
+data class Invitation(
+    val id: Int?,
+    val actionId: Int,
+    val actionName: String,
+    val invitedUser: UserProfile,
+    val accepted: Boolean? = null
+)

--- a/app/src/main/java/io/github/sustainow/domain/model/MemberActivity.kt
+++ b/app/src/main/java/io/github/sustainow/domain/model/MemberActivity.kt
@@ -1,15 +1,25 @@
 package io.github.sustainow.domain.model
 
 import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import java.time.OffsetDateTime
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
-data class MemberActivity @OptIn(ExperimentalUuidApi::class) constructor(
-    val id: Int? =null,
-    val authorId: Uuid,
-    val authorName: String,
+data class MemberActivity (
+    val id: Int? = null,
+    val memberProfile: UserProfile,
     val actionId: Int,
-    val type: ActivityType
+    val type: ActivityType,
+    val comment: String? = null,
+    val date: LocalDateTime
+)
+
+data class MemberActivityCreate (
+    val memberId: String,
+    val actionId: Int,
+    val type: ActivityType,
+    val comment: String? = null
 )
 
 enum class ActivityType(val type: String) {

--- a/app/src/main/java/io/github/sustainow/domain/model/MemberActivity.kt
+++ b/app/src/main/java/io/github/sustainow/domain/model/MemberActivity.kt
@@ -1,0 +1,19 @@
+package io.github.sustainow.domain.model
+
+import kotlinx.datetime.LocalDate
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+data class MemberActivity @OptIn(ExperimentalUuidApi::class) constructor(
+    val id: Int? =null,
+    val authorId: Uuid,
+    val authorName: String,
+    val actionId: Int,
+    val type: ActivityType
+)
+
+enum class ActivityType(val type: String) {
+    COMMENT("comment"),
+    JOIN("join"),
+    CHANGE_STATUS("change_status"),
+}

--- a/app/src/main/java/io/github/sustainow/domain/model/UserProfile.kt
+++ b/app/src/main/java/io/github/sustainow/domain/model/UserProfile.kt
@@ -1,0 +1,10 @@
+package io.github.sustainow.domain.model
+
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+data class UserProfile @OptIn(ExperimentalUuidApi::class) constructor(
+    val id:Uuid,
+    val fullName: String,
+    val profilePicture: String? = null
+)

--- a/app/src/main/java/io/github/sustainow/presentation/ui/actions/SearchCollectiveActionsScreen.kt
+++ b/app/src/main/java/io/github/sustainow/presentation/ui/actions/SearchCollectiveActionsScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Sort
@@ -46,6 +47,7 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import io.github.sustainow.R
 import io.github.sustainow.presentation.ui.components.CollectiveActionCard
+import io.github.sustainow.presentation.ui.components.InvitationCard
 import io.github.sustainow.presentation.ui.components.LoadingModal
 import io.github.sustainow.presentation.ui.utils.toLocalDate
 import io.github.sustainow.presentation.viewmodel.SearchCollectiveActionsViewModel
@@ -62,6 +64,7 @@ fun SearchCollectiveActionsScreen(navController:NavController, viewModel:SearchC
     val endDate by viewModel.endDate.collectAsState()
 
     val actions by viewModel.collectiveActions.collectAsState()
+    val invitations by viewModel.invitations.collectAsState()
     val loading by viewModel.loading.collectAsState()
 
     val dateRangePickerState = rememberDateRangePickerState()
@@ -77,6 +80,14 @@ fun SearchCollectiveActionsScreen(navController:NavController, viewModel:SearchC
     }}, content =  { innerPadding ->
     Column(modifier=modifier.fillMaxSize().padding(innerPadding), horizontalAlignment = Alignment.CenterHorizontally){
        Text(stringResource(id = R.string.collective_actions_search_title),style=MaterialTheme.typography.displaySmall)
+        LazyColumn{
+           items(invitations ?: emptyList()) {
+               InvitationCard(it) { bool ->
+                   val response = it.copy(accepted = bool)
+                   viewModel.respondInvitation(response)
+               }
+           }
+        }
         SearchBar(
             inputField = {
                 SearchBarDefaults.InputField(

--- a/app/src/main/java/io/github/sustainow/presentation/ui/actions/ViewCollectiveActionScreen.kt
+++ b/app/src/main/java/io/github/sustainow/presentation/ui/actions/ViewCollectiveActionScreen.kt
@@ -1,11 +1,12 @@
 package io.github.sustainow.presentation.ui.actions
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -18,6 +19,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Today
 import androidx.compose.material3.AssistChip
@@ -30,7 +32,9 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -44,180 +48,258 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import coil.compose.SubcomposeAsyncImage
-import coil.compose.rememberAsyncImagePainter
 import io.github.sustainow.R
 import io.github.sustainow.domain.model.UserState
+import io.github.sustainow.presentation.ui.components.ActivityDescription
 import io.github.sustainow.presentation.ui.components.LoadingModal
+import io.github.sustainow.presentation.ui.components.UserProfileCard
 import io.github.sustainow.presentation.viewmodel.CollectiveActionViewModel
 import kotlinx.datetime.toJavaLocalDate
 import java.time.format.DateTimeFormatter
+import kotlin.uuid.ExperimentalUuidApi
 
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalUuidApi::class, ExperimentalLayoutApi::class)
 @Composable
 fun CollectiveActionScreen(userState: UserState, viewModel:CollectiveActionViewModel, modifier: Modifier = Modifier, navigateEditCallback: ()->Unit, returnCallback: ()->Unit) {
     val action by viewModel.action.collectAsState()
+    val activities by viewModel.activities.collectAsState()
+    val comment by viewModel.comment.collectAsState()
     val loading by viewModel.loading.collectAsState()
 
     var showConfirmDelete by remember { mutableStateOf(false) }
+
+    val commentMaxLength= 180
 
     if(loading){
         LoadingModal()
     }
     else {
         if (action != null) {
-            Column(
-                modifier = modifier.fillMaxSize().padding(24.dp).verticalScroll( rememberScrollState()),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(32.dp)
-            ) {
-                SubcomposeAsyncImage(
-                    model = action!!.images.firstOrNull() ?: R.drawable.image_not_found,
-                    contentDescription = null,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .heightIn(0.dp, 300.dp)
-                        .border(BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)),
-                    contentScale = ContentScale.Crop,
-                    loading={LoadingModal()}
-                )
-                Row(modifier=modifier.fillMaxWidth()) {
-                    Text(
-                        text = action!!.name,
-                        style = MaterialTheme.typography.titleLarge,
-                        modifier = modifier.padding(8.dp).fillMaxWidth(0.8f)
+                Column(
+                    modifier = modifier.fillMaxSize().padding(24.dp)
+                        .verticalScroll(rememberScrollState()),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(32.dp)
+                ) {
+                    SubcomposeAsyncImage(
+                        model = action!!.images.firstOrNull() ?: R.drawable.image_not_found,
+                        contentDescription = null,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(0.dp, 300.dp)
+                            .border(BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)),
+                        contentScale = ContentScale.Crop,
+                        loading = { LoadingModal() }
                     )
-                    if (userState is UserState.Logged) {
-                        if (action!!.authorId == userState.user.uid) {
-                            IconButton(onClick = {navigateEditCallback()},modifier=Modifier.size(48.dp) ){
-                                Icon(Icons.Default.Edit, contentDescription = null)
+                    Row(modifier = modifier.fillMaxWidth()) {
+                        Text(
+                            text = action!!.name,
+                            style = MaterialTheme.typography.titleLarge,
+                            modifier = modifier.padding(8.dp).fillMaxWidth(0.8f)
+                        )
+                        if (userState is UserState.Logged) {
+                            if (action!!.authorId.toString() == userState.user.uid) {
+                                IconButton(
+                                    onClick = { navigateEditCallback() },
+                                    modifier = Modifier.size(48.dp)
+                                ) {
+                                    Icon(Icons.Default.Edit, contentDescription = null)
+                                }
                             }
                         }
                     }
-                }
 
-                Text(
-                    text = "${stringResource(R.string.view_collective_action_author_text)} ${action!!.authorName}",
-                    color=MaterialTheme.colorScheme.onSurface,
-                    modifier = Modifier.padding(8.dp).align(Alignment.Start),
-                    style=MaterialTheme.typography.labelLarge
-                )
-                HorizontalDivider(
-                    modifier.fillMaxWidth(),
-                )
-
-
-                Row(
-                    modifier = Modifier.padding(8.dp).fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    AssistChip(
-                        onClick={},
-                        leadingIcon={Icon(Icons.Default.Today, contentDescription = null)},
-                        label= {Text(
-                            text = action!!.startDate.toJavaLocalDate()
-                                .format(DateTimeFormatter.ofPattern("dd/MM/yyyy")),
-                            color=MaterialTheme.colorScheme.onSurface,
-                            style = MaterialTheme.typography.labelMedium
-                        )}
-                    )
-                    AssistChip(
-                        onClick = {},
-                        leadingIcon = {Icon(Icons.Default.Today, contentDescription = null)},
-                        label = {Text(
-                            text = action!!.endDate.toJavaLocalDate()
-                                .format(DateTimeFormatter.ofPattern("dd/MM/yyyy")),
-                            color=MaterialTheme.colorScheme.onSurface,
-                            style = MaterialTheme.typography.labelMedium
-                        )})
-                }
-
-                Row (
-                    modifier = Modifier.padding(8.dp).fillMaxWidth(),
-                ){
-                    AssistChip(
-                        onClick = {},
-                        label= {Text(
-                            text = action!!.status,
-                            color=MaterialTheme.colorScheme.onSurface,
-                            style = MaterialTheme.typography.labelMedium
-                        )},
-                        border= BorderStroke(1.dp, MaterialTheme.colorScheme.secondary)
-                    )
-                }
-
-                Column(modifier=modifier.fillMaxWidth().clip(
-                    RoundedCornerShape(16.dp)
-                ).background(MaterialTheme.colorScheme.surfaceContainerHigh).padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)){
                     Text(
-                        text = stringResource(R.string.view_collective_action_description_header),
-                        color=MaterialTheme.colorScheme.onSurfaceVariant,
-                        style = MaterialTheme.typography.headlineSmall,
-                        modifier = Modifier.padding(8.dp)
+                        text = "${stringResource(R.string.view_collective_action_author_text)} ${action!!.authorName}",
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.padding(8.dp).align(Alignment.Start),
+                        style = MaterialTheme.typography.labelLarge
+                    )
+                    val totalMembers = action!!.members.size + 1
+                    val memberDescription = if(totalMembers > 1) "$totalMembers Membros" else "$totalMembers Membro"
+                    Text(
+                        text = memberDescription,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.padding(8.dp).align(Alignment.Start),
+                        style = MaterialTheme.typography.labelLarge
                     )
                     HorizontalDivider(
                         modifier.fillMaxWidth(),
                     )
-                Text(
-                    text = action!!.description,
-                    color=MaterialTheme.colorScheme.onSurface,
-                    style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.padding(8.dp)
-                )
-                }
-                if (userState is UserState.Logged) {
-                    if (action!!.authorId == userState.user.uid) {
-                        Button(onClick = {showConfirmDelete=true},
-                            colors= ButtonColors(
-                                containerColor = MaterialTheme.colorScheme.error,
-                                contentColor = MaterialTheme.colorScheme.onError,
-                                disabledContainerColor = MaterialTheme.colorScheme.errorContainer,
-                                disabledContentColor = MaterialTheme.colorScheme.onErrorContainer,
-                            )
-                        ) {
-                            Text("Remover")
+
+
+                    Row(
+                        modifier = Modifier.padding(8.dp).fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        AssistChip(
+                            onClick = {},
+                            leadingIcon = { Icon(Icons.Default.Today, contentDescription = null) },
+                            label = {
+                                Text(
+                                    text = action!!.startDate.toJavaLocalDate()
+                                        .format(DateTimeFormatter.ofPattern("dd/MM/yyyy")),
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                    style = MaterialTheme.typography.labelMedium
+                                )
+                            }
+                        )
+                        AssistChip(
+                            onClick = {},
+                            leadingIcon = { Icon(Icons.Default.Today, contentDescription = null) },
+                            label = {
+                                Text(
+                                    text = action!!.endDate.toJavaLocalDate()
+                                        .format(DateTimeFormatter.ofPattern("dd/MM/yyyy")),
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                    style = MaterialTheme.typography.labelMedium
+                                )
+                            })
+                    }
+
+                    Row(
+                        modifier = Modifier.padding(8.dp).fillMaxWidth(),
+                    ) {
+                        AssistChip(
+                            onClick = {},
+                            label = {
+                                Text(
+                                    text = action!!.status,
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                    style = MaterialTheme.typography.labelMedium
+                                )
+                            },
+                            border = BorderStroke(1.dp, MaterialTheme.colorScheme.secondary)
+                        )
+                    }
+
+                    Column(
+                        modifier = modifier.fillMaxWidth().clip(
+                            RoundedCornerShape(16.dp)
+                        ).background(MaterialTheme.colorScheme.surfaceContainerHigh).padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.view_collective_action_description_header),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            style = MaterialTheme.typography.headlineSmall,
+                            modifier = Modifier.padding(8.dp)
+                        )
+                        HorizontalDivider(
+                            modifier.fillMaxWidth(),
+                        )
+                        Text(
+                            text = action!!.description,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.padding(8.dp)
+                        )
+                    }
+                    Column(
+                        modifier = modifier.fillMaxWidth().clip(
+                            RoundedCornerShape(16.dp)
+                        ).background(MaterialTheme.colorScheme.surfaceContainer).padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.view_collective_action_activity_title),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            style = MaterialTheme.typography.headlineSmall,
+                            modifier = Modifier.padding(8.dp)
+                        )
+                        HorizontalDivider(
+                            modifier.fillMaxWidth(),
+                        )
+
+                        Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                            if (activities?.isNotEmpty() == true) {
+                                activities?.forEach {
+                                    ActivityDescription(it)
+                                }
+                            } else {
+                                Text("Nenhuma atividade ainda")
+                            }
                         }
-                        if(showConfirmDelete) {
-                            BasicAlertDialog(
-                                onDismissRequest = { showConfirmDelete = false },
-                                content = {
-                                    Card(modifier = modifier.requiredSize(300.dp, 100.dp)) {
-                                        Column(
-                                            modifier = modifier.fillMaxSize().padding(8.dp,16.dp),
-                                            verticalArrangement = Arrangement.spacedBy(10.dp),
-                                            horizontalAlignment = Alignment.CenterHorizontally,
-                                        ) {
+                        if (userState is UserState.Logged){
+                            if(action!!.members.any {it.id.toString() == userState.user.uid} || action!!.authorId.toString() == userState.user.uid){
+                                Row(modifier=modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically){
+                                    OutlinedTextField(value = comment,
+                                        onValueChange = {viewModel.setComment(it)},
+                                        label= { Text("Adicione um comentário") },
+                                        supportingText = { Text("${comment.length}/$commentMaxLength",style=MaterialTheme.typography.labelSmall) },
+                                        modifier= modifier.fillMaxWidth(0.9f)
+
+                                    )
+                                    IconButton(
+                                        onClick = {viewModel.sendComment()},
+                                        enabled = comment.isNotEmpty(),
+                                        modifier = modifier.size(48.dp)
+                                    ) {
+                                        Icon(Icons.AutoMirrored.Filled.Send, contentDescription = null)
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if (userState is UserState.Logged) {
+                        if (action!!.authorId.toString() == userState.user.uid) {
+                            Button(
+                                onClick = { showConfirmDelete = true },
+                                colors = ButtonColors(
+                                    containerColor = MaterialTheme.colorScheme.error,
+                                    contentColor = MaterialTheme.colorScheme.onError,
+                                    disabledContainerColor = MaterialTheme.colorScheme.errorContainer,
+                                    disabledContentColor = MaterialTheme.colorScheme.onErrorContainer,
+                                )
+                            ) {
+                                Text("Remover")
+                            }
+                            if (showConfirmDelete) {
+                                BasicAlertDialog(
+                                    onDismissRequest = { showConfirmDelete = false },
+                                    content = {
+                                        Card(modifier = modifier.requiredSize(300.dp, 100.dp)) {
+                                            Column(
+                                                modifier = modifier.fillMaxSize()
+                                                    .padding(8.dp, 16.dp),
+                                                verticalArrangement = Arrangement.spacedBy(10.dp),
+                                                horizontalAlignment = Alignment.CenterHorizontally,
+                                            ) {
                                                 Text("Deseja mesmo excluir essa ação?")
                                                 Row(
                                                     modifier = modifier.fillMaxWidth(),
                                                     horizontalArrangement = Arrangement.SpaceAround
                                                 ) {
-                                                    Button(onClick = { showConfirmDelete = false }) {
+                                                    Button(onClick = {
+                                                        showConfirmDelete = false
+                                                    }) {
                                                         Text("Cancelar")
                                                     }
                                                     Button(onClick = { viewModel.delete() }) {
                                                         Text("Confirmar")
                                                     }
                                                 }
+                                            }
                                         }
-                                    }
-                                })
+                                    })
+                            }
                         }
                     }
                 }
-            }
-        } else {
-            Column(
-                modifier = modifier.fillMaxSize().padding(24.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center
-            ) {
-                Text(stringResource(R.string.view_collective_action_not_found_text))
-                Button(onClick = returnCallback) {
-                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
-                    Text(stringResource(R.string.view_collective_action_back_text))
+            } else {
+                Column(
+                    modifier = modifier.fillMaxSize().padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Text(stringResource(R.string.view_collective_action_not_found_text))
+                    Button(onClick = returnCallback) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                        Text(stringResource(R.string.view_collective_action_back_text))
+                    }
                 }
             }
         }
     }
-}

--- a/app/src/main/java/io/github/sustainow/presentation/ui/components/ActivityDescription.kt
+++ b/app/src/main/java/io/github/sustainow/presentation/ui/components/ActivityDescription.kt
@@ -1,73 +1,141 @@
 package io.github.sustainow.presentation.ui.components
 
-import android.util.Log
+import androidx.compose.animation.core.Animatable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonColors
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import coil.compose.SubcomposeAsyncImage
 import io.github.sustainow.R
 import io.github.sustainow.domain.model.ActivityType
 import io.github.sustainow.domain.model.MemberActivity
+import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDate
-import kotlinx.datetime.format
-import kotlinx.datetime.format.DateTimeFormat
 import kotlinx.datetime.format.char
 import kotlinx.datetime.toJavaLocalDateTime
 import kotlinx.datetime.toKotlinLocalDate
-import java.time.format.DateTimeFormatter
 
 @Composable
-fun ActivityDescription(activity: MemberActivity) {
-    Row(modifier= Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-        verticalAlignment = Alignment.CenterVertically){
-          if (activity.memberProfile.profilePicture!= null) {
-                SubcomposeAsyncImage(
-                    model = activity.memberProfile.profilePicture,
-                    contentDescription = "Profile Picture",
-                    modifier = Modifier.requiredSize(48.dp, 48.dp),
-                    loading = { LoadingModal() })
-            } else {
-                Icon(
-                    imageVector = Icons.Default.AccountCircle,
-                    contentDescription = "Profile Picture",
-                    modifier = Modifier.requiredSize(48.dp, 48.dp)
-                )
-            }
-        Column(modifier = Modifier.fillMaxWidth()){
-            val monthYearFormat = LocalDate.Format {
-                monthNumber(); char('/'); yearTwoDigits(1970)
-            }
-            Row(modifier=Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically,horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                Text(titleForActivity(activity), style = MaterialTheme.typography.titleSmall)
-                Text(
-                    monthYearFormat.format(
-                        activity.date.toJavaLocalDateTime().toLocalDate().toKotlinLocalDate()
-                    ),
-                    style = MaterialTheme.typography.bodySmall,
-                    modifier = Modifier.widthIn(30.dp, 60.dp)
-                )
-            }
-            if(activity.comment != null){
-                Text(activity.comment,style=MaterialTheme.typography.bodySmall)
+fun ActivityDescription(activity: MemberActivity, removable:Boolean=false,onRemove:()->Unit={}) {
+    var optionsRowWidth by remember{
+        mutableFloatStateOf(0f)
+    }
+    val offset = remember{
+        Animatable(initialValue = 0f)
+    }
+    val scope = rememberCoroutineScope()
+
+    Box(modifier=Modifier.fillMaxWidth()){
+        Row(modifier=Modifier.onSizeChanged { optionsRowWidth = it.width.toFloat() }){
+            if(removable){
+                IconButton(onClick = onRemove,
+                    colors= IconButtonDefaults.iconButtonColors(containerColor = MaterialTheme.colorScheme.error),
+                    modifier=Modifier.padding(4.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Delete,
+                        contentDescription = "Profile Picture",
+                        modifier = Modifier.requiredSize(24.dp, 24.dp),
+                        tint=MaterialTheme.colorScheme.onError
+                    )
+                }
             }
         }
-
-
-
+        Surface(modifier= Modifier
+            .fillMaxWidth()
+            .offset{ IntOffset(offset.value.toInt(),0) }
+            .pointerInput(true){
+                detectHorizontalDragGestures(
+                    onHorizontalDrag =  { _, dragAmount ->
+                        scope.launch{
+                            val newOffset = (offset.value+dragAmount).coerceIn(0f,optionsRowWidth)
+                            offset.snapTo(newOffset)
+                        }
+                    },
+                    onDragEnd = {
+                        when{
+                            offset.value >= optionsRowWidth / 2f -> {
+                                scope.launch {
+                                    offset.animateTo(optionsRowWidth)
+                                }
+                            }
+                            else ->{
+                                scope.launch {
+                                    offset.animateTo(0f)
+                                }
+                            }
+                        }
+                    })
+            }){
+            Row(modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalAlignment = Alignment.CenterVertically) {
+                if (activity.memberProfile.profilePicture != null) {
+                    SubcomposeAsyncImage(
+                        model = activity.memberProfile.profilePicture,
+                        contentDescription = "Profile Picture",
+                        modifier = Modifier.requiredSize(48.dp, 48.dp),
+                        loading = { LoadingModal() })
+                } else {
+                    Icon(
+                        imageVector = Icons.Default.AccountCircle,
+                        contentDescription = "Profile Picture",
+                        modifier = Modifier.requiredSize(48.dp, 48.dp)
+                    )
+                }
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    val monthYearFormat = LocalDate.Format {
+                        monthNumber(); char('/'); yearTwoDigits(1970)
+                    }
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        Text(titleForActivity(activity), style = MaterialTheme.typography.titleSmall)
+                        Text(
+                            monthYearFormat.format(
+                                activity.date.toJavaLocalDateTime().toLocalDate().toKotlinLocalDate()
+                            ),
+                            style = MaterialTheme.typography.bodySmall,
+                            modifier = Modifier.widthIn(30.dp, 60.dp)
+                        )
+                    }
+                    if (activity.comment != null) {
+                        Text(activity.comment, style = MaterialTheme.typography.bodySmall)
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/java/io/github/sustainow/presentation/ui/components/ActivityDescription.kt
+++ b/app/src/main/java/io/github/sustainow/presentation/ui/components/ActivityDescription.kt
@@ -1,0 +1,81 @@
+package io.github.sustainow.presentation.ui.components
+
+import android.util.Log
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import coil.compose.SubcomposeAsyncImage
+import io.github.sustainow.R
+import io.github.sustainow.domain.model.ActivityType
+import io.github.sustainow.domain.model.MemberActivity
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.format
+import kotlinx.datetime.format.DateTimeFormat
+import kotlinx.datetime.format.char
+import kotlinx.datetime.toJavaLocalDateTime
+import kotlinx.datetime.toKotlinLocalDate
+import java.time.format.DateTimeFormatter
+
+@Composable
+fun ActivityDescription(activity: MemberActivity) {
+    Row(modifier= Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically){
+          if (activity.memberProfile.profilePicture!= null) {
+                SubcomposeAsyncImage(
+                    model = activity.memberProfile.profilePicture,
+                    contentDescription = "Profile Picture",
+                    modifier = Modifier.requiredSize(48.dp, 48.dp),
+                    loading = { LoadingModal() })
+            } else {
+                Icon(
+                    imageVector = Icons.Default.AccountCircle,
+                    contentDescription = "Profile Picture",
+                    modifier = Modifier.requiredSize(48.dp, 48.dp)
+                )
+            }
+        Column(modifier = Modifier.fillMaxWidth()){
+            val monthYearFormat = LocalDate.Format {
+                monthNumber(); char('/'); yearTwoDigits(1970)
+            }
+            Row(modifier=Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically,horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(titleForActivity(activity), style = MaterialTheme.typography.titleSmall)
+                Text(
+                    monthYearFormat.format(
+                        activity.date.toJavaLocalDateTime().toLocalDate().toKotlinLocalDate()
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.widthIn(30.dp, 60.dp)
+                )
+            }
+            if(activity.comment != null){
+                Text(activity.comment,style=MaterialTheme.typography.bodySmall)
+            }
+        }
+
+
+
+    }
+}
+
+@Composable
+private fun titleForActivity(activity: MemberActivity): String {
+    return when (activity.type) {
+        ActivityType.COMMENT -> stringResource(R.string.activity_comment_title, formatArgs = arrayOf(activity.memberProfile.fullName))
+        ActivityType.JOIN -> stringResource(R.string.activity_joined_title, formatArgs = arrayOf(activity.memberProfile.fullName))
+        ActivityType.CHANGE_STATUS -> stringResource(R.string.activity_changed_status_title, formatArgs = arrayOf(activity.memberProfile.fullName))
+    }
+}

--- a/app/src/main/java/io/github/sustainow/presentation/ui/components/InvitationCard.kt
+++ b/app/src/main/java/io/github/sustainow/presentation/ui/components/InvitationCard.kt
@@ -1,0 +1,75 @@
+package io.github.sustainow.presentation.ui.components
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardColors
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CardElevation
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import io.github.sustainow.R
+import io.github.sustainow.domain.model.Invitation
+
+@Composable
+fun InvitationCard(invite:Invitation, answerCallback: (Boolean)->Unit){
+    val interactionSource = remember { MutableInteractionSource() }
+    val isHovered by interactionSource.collectIsHoveredAsState()
+
+    ElevatedCard (
+        shape = RoundedCornerShape(12.dp),
+        elevation = CardDefaults.elevatedCardElevation(defaultElevation = 8.dp, hoveredElevation = 10.dp, pressedElevation = 12.dp),
+        colors = CardColors(
+            containerColor = if (isHovered) MaterialTheme.colorScheme.surfaceContainerHighest else MaterialTheme.colorScheme.surfaceContainerLowest,
+            contentColor = MaterialTheme.colorScheme.onSurface,
+            disabledContainerColor = MaterialTheme.colorScheme.surfaceContainer,
+            disabledContentColor = MaterialTheme.colorScheme.onSurface,
+        ),
+        modifier = Modifier.padding(4.dp).fillMaxWidth(0.8f).shadow(
+            elevation=10.dp,
+            shape = RoundedCornerShape(12.dp)
+        ),
+    ) {
+        Column(modifier=Modifier.padding(12.dp)){
+        Text(
+            stringResource(
+               id= R.string.invitation_card_title,
+                formatArgs = arrayOf(invite.actionName)
+            )
+        )
+        Row(horizontalArrangement = Arrangement.SpaceAround, modifier=Modifier.fillMaxWidth()) {
+            Button(onClick = {answerCallback(true)}){
+                Text("Aceitar")
+            }
+            Button(onClick = {answerCallback(false)},
+                   colors= ButtonColors(
+                       containerColor = MaterialTheme.colorScheme.error,
+                       contentColor = MaterialTheme.colorScheme.onError,
+                       disabledContainerColor = MaterialTheme.colorScheme.errorContainer,
+                       disabledContentColor = MaterialTheme.colorScheme.onErrorContainer,
+                   )
+            ){
+                Text("Recusar")
+            }
+        }
+        }
+    }
+
+}
+

--- a/app/src/main/java/io/github/sustainow/presentation/ui/components/UserProfileCard.kt
+++ b/app/src/main/java/io/github/sustainow/presentation/ui/components/UserProfileCard.kt
@@ -1,0 +1,59 @@
+package io.github.sustainow.presentation.ui.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.compose.SubcomposeAsyncImage
+import io.github.sustainow.domain.model.UserProfile
+
+@Composable
+fun UserProfileCard(userProfile: UserProfile,onClick:()->Unit) {
+    OutlinedCard(
+        colors=CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLowest,
+        ),
+        modifier= Modifier.padding(4.dp).fillMaxWidth().clickable { onClick() },
+        shape = RoundedCornerShape(32.dp),
+        border= BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+        elevation = CardDefaults.elevatedCardElevation(
+            defaultElevation = 8.dp,
+            hoveredElevation = 10.dp,
+            pressedElevation = 12.dp)) {
+
+        Row(verticalAlignment = Alignment.CenterVertically){
+            if (userProfile.profilePicture != null) {
+                SubcomposeAsyncImage(
+                    model = userProfile.profilePicture ?: Icons.Default.AccountCircle,
+                    contentDescription = "Profile Picture",
+                    modifier = Modifier.requiredSize(48.dp, 48.dp),
+                    loading = { LoadingModal() })
+            } else {
+                Icon(
+                    imageVector = Icons.Default.AccountCircle,
+                    contentDescription = "Profile Picture",
+                    modifier = Modifier.requiredSize(48.dp, 48.dp)
+                )
+            }
+            Text(text = userProfile.fullName)
+        }
+
+    }
+}

--- a/app/src/main/java/io/github/sustainow/presentation/viewmodel/CollectiveActionViewModel.kt
+++ b/app/src/main/java/io/github/sustainow/presentation/viewmodel/CollectiveActionViewModel.kt
@@ -208,6 +208,23 @@ class CollectiveActionViewModel @AssistedInject constructor(private val authServ
             }
         }
     }
+    fun removeComment(id:Int){
+        viewModelScope.launch {
+            try {
+                val currentUserState = authService.user.value
+                if (currentUserState is UserState.Logged) {
+                    repository.removeComment(
+                        id
+                    )
+                    _activities.value = repository.listActionActivities(_action.value!!.id!!)
+                }
+            }
+            catch (e: Exception){
+                _error.value = "Erro ao remover comentário"
+                Log.e("CollectiveActionViewModel", "Error removing comment", e)
+            }
+        }
+    }
 
     fun setComment(text: String){
         if(text.length<180) {

--- a/app/src/main/java/io/github/sustainow/repository/actions/CollectiveActionRepository.kt
+++ b/app/src/main/java/io/github/sustainow/repository/actions/CollectiveActionRepository.kt
@@ -3,6 +3,7 @@ package io.github.sustainow.repository.actions
 import io.github.sustainow.domain.model.MemberActivity
 import io.github.sustainow.domain.model.CollectiveAction
 import io.github.sustainow.domain.model.Invitation
+import io.github.sustainow.domain.model.MemberActivityCreate
 import io.github.sustainow.domain.model.UserProfile
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -13,11 +14,12 @@ interface CollectiveActionRepository {
     suspend fun create(collectiveAction: CollectiveAction): CollectiveAction
     suspend fun update(collectiveAction: CollectiveAction): CollectiveAction
     suspend fun delete(id: Int)
+    suspend fun listActionActivities(actionId: Int): List<MemberActivity>
     @OptIn(ExperimentalUuidApi::class)
     suspend fun listPendingInvitations(userId:Uuid): List<Invitation>
     suspend fun listActionInvitations(actionId: Int): List<Invitation>
     suspend fun inviteMembers(id: Int, emails: List<UserProfile>)
     suspend fun answerInvitation(invitation: Invitation)
-    suspend fun addComment(comment: MemberActivity)
+    suspend fun addComment(comment: MemberActivityCreate)
     suspend fun removeComment(id: Int)
 }

--- a/app/src/main/java/io/github/sustainow/repository/actions/CollectiveActionRepository.kt
+++ b/app/src/main/java/io/github/sustainow/repository/actions/CollectiveActionRepository.kt
@@ -18,7 +18,7 @@ interface CollectiveActionRepository {
     @OptIn(ExperimentalUuidApi::class)
     suspend fun listPendingInvitations(userId:Uuid): List<Invitation>
     suspend fun listActionInvitations(actionId: Int): List<Invitation>
-    suspend fun inviteMembers(id: Int, emails: List<UserProfile>)
+    suspend fun inviteMembers(id: Int, userProfiles: Iterable<UserProfile>)
     suspend fun answerInvitation(invitation: Invitation)
     suspend fun addComment(comment: MemberActivityCreate)
     suspend fun removeComment(id: Int)

--- a/app/src/main/java/io/github/sustainow/repository/actions/CollectiveActionRepository.kt
+++ b/app/src/main/java/io/github/sustainow/repository/actions/CollectiveActionRepository.kt
@@ -1,6 +1,11 @@
 package io.github.sustainow.repository.actions
 
+import io.github.sustainow.domain.model.MemberActivity
 import io.github.sustainow.domain.model.CollectiveAction
+import io.github.sustainow.domain.model.Invitation
+import io.github.sustainow.domain.model.UserProfile
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 interface CollectiveActionRepository {
     suspend fun list(): List<CollectiveAction>
@@ -8,4 +13,11 @@ interface CollectiveActionRepository {
     suspend fun create(collectiveAction: CollectiveAction): CollectiveAction
     suspend fun update(collectiveAction: CollectiveAction): CollectiveAction
     suspend fun delete(id: Int)
+    @OptIn(ExperimentalUuidApi::class)
+    suspend fun listPendingInvitations(userId:Uuid): List<Invitation>
+    suspend fun listActionInvitations(actionId: Int): List<Invitation>
+    suspend fun inviteMembers(id: Int, emails: List<UserProfile>)
+    suspend fun answerInvitation(invitation: Invitation)
+    suspend fun addComment(comment: MemberActivity)
+    suspend fun removeComment(id: Int)
 }

--- a/app/src/main/java/io/github/sustainow/repository/mapper/SupabaseMapper.kt
+++ b/app/src/main/java/io/github/sustainow/repository/mapper/SupabaseMapper.kt
@@ -7,6 +7,7 @@ import io.github.sustainow.domain.model.Formulary
 import io.github.sustainow.domain.model.FormularyAnswer
 import io.github.sustainow.domain.model.Invitation
 import io.github.sustainow.domain.model.MemberActivity
+import io.github.sustainow.domain.model.MemberActivityCreate
 import io.github.sustainow.domain.model.Question
 import io.github.sustainow.domain.model.QuestionAlternative
 import io.github.sustainow.domain.model.UserProfile
@@ -273,14 +274,10 @@ class SupabaseMapper {
         )
     }
 
-    @OptIn(ExperimentalUuidApi::class)
-    fun toSerializableCreate(domain: MemberActivity): SerializableMemberActivityCreate{
-        if(domain.id== null){
-            throw IllegalArgumentException("MemberActivity id cannot be null or blank")
-        }
+    fun toSerializableCreate(domain: MemberActivityCreate): SerializableMemberActivityCreate{
         return SerializableMemberActivityCreate(
             actionId = domain.actionId,
-            memberId = domain.memberProfile.id.toString(),
+            memberId = domain.memberId,
             activityType = domain.type.type,
             comment = domain.comment,
         )

--- a/app/src/main/java/io/github/sustainow/repository/mapper/SupabaseMapper.kt
+++ b/app/src/main/java/io/github/sustainow/repository/mapper/SupabaseMapper.kt
@@ -1,20 +1,29 @@
 package io.github.sustainow.repository.mapper
 
 import android.net.Uri
+import io.github.sustainow.domain.model.ActivityType
 import io.github.sustainow.domain.model.CollectiveAction
 import io.github.sustainow.domain.model.Formulary
 import io.github.sustainow.domain.model.FormularyAnswer
+import io.github.sustainow.domain.model.Invitation
+import io.github.sustainow.domain.model.MemberActivity
 import io.github.sustainow.domain.model.Question
 import io.github.sustainow.domain.model.QuestionAlternative
+import io.github.sustainow.domain.model.UserProfile
 import io.github.sustainow.repository.model.SerializableCollectiveAction
+import io.github.sustainow.repository.model.SerializableCollectiveActionBaseInfo
 import io.github.sustainow.repository.model.SerializableCollectiveActionCreate
 import io.github.sustainow.repository.model.SerializableCollectiveActionUpdate
 import io.github.sustainow.repository.model.SerializableFormulary
 import io.github.sustainow.repository.model.SerializableFormularyAnswer
+import io.github.sustainow.repository.model.SerializableInvitation
+import io.github.sustainow.repository.model.SerializableMemberActivity
 import io.github.sustainow.repository.model.SerializableQuestion
 import io.github.sustainow.repository.model.SerializableQuestionAlternative
 import io.github.sustainow.repository.model.SerializableQuestionDependency
 import io.github.sustainow.repository.model.SerializableUserMetadata
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
 
 class SupabaseMapper {
     fun toDomain(serialized: SerializableFormulary): Formulary {
@@ -193,8 +202,8 @@ class SupabaseMapper {
             } ?: emptyList(),
             name = serialized.name,
             description = serialized.description,
-            authorId = serialized.metadata.authorId,
-            authorName = serialized.metadata.authorName,
+            authorId = serialized.metadata.id,
+            authorName = serialized.metadata.name,
             startDate = serialized.startDate,
             endDate = serialized.endDate,
             status = serialized.status
@@ -209,7 +218,7 @@ class SupabaseMapper {
             },
             name = domain.name,
             description = domain.description,
-            metadata = SerializableUserMetadata(authorId=domain.authorId,authorName = domain.authorName),
+            metadata = SerializableUserMetadata(id=domain.authorId,name = domain.authorName),
             startDate = domain.startDate,
             endDate = domain.endDate,
             status = domain.status
@@ -237,4 +246,46 @@ class SupabaseMapper {
             status = domain.status
         )
     }
+
+    @OptIn(ExperimentalUuidApi::class)
+    fun toDomain(serialized: SerializableInvitation): Invitation {
+        return Invitation(
+            id = serialized.id,
+            invitedUser = UserProfile(Uuid.parse(serialized.invitedUser.id),serialized.invitedUser.name),
+            actionId = serialized.action.id,
+            actionName = serialized.action.name,
+            accepted = serialized.accepted
+        )
+    }
+    @OptIn(ExperimentalUuidApi::class)
+    fun toSerializable(domain:Invitation):SerializableInvitation {
+        return SerializableInvitation(
+            id = domain.id,
+            invitedUser = SerializableUserMetadata(id = domain.invitedUser.id.toString(),name = domain.invitedUser.fullName),
+            action = SerializableCollectiveActionBaseInfo(id = domain.actionId,name = domain.actionName),
+            accepted = domain.accepted
+        )
+    }
+
+    @OptIn(ExperimentalUuidApi::class)
+    fun toDomain(serialized: SerializableMemberActivity): MemberActivity{
+        return MemberActivity(
+            id=serialized.id,
+            authorId = Uuid.parse(serialized.member.id),
+            authorName = serialized.member.name,
+            actionId = serialized.actionId,
+            type = serialized.activityType
+        )
+    }
+
+    @OptIn(ExperimentalUuidApi::class)
+    fun toSerializable(domain: MemberActivity): SerializableMemberActivity{
+        return SerializableMemberActivity(
+            id = domain.id,
+            actionId = domain.actionId,
+            member = SerializableUserMetadata(id = domain.authorId.toString(),name = domain.authorName),
+            activityType = domain.type
+        )
+    }
+
 }

--- a/app/src/main/java/io/github/sustainow/repository/model/SerializableActionMember.kt
+++ b/app/src/main/java/io/github/sustainow/repository/model/SerializableActionMember.kt
@@ -1,0 +1,12 @@
+package io.github.sustainow.repository.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SerializableActionMember (
+    @SerialName("action_id")
+    val actionId: Int,
+    @SerialName("user_id")
+    val userId: String,
+)

--- a/app/src/main/java/io/github/sustainow/repository/model/SerializableCollectiveAction.kt
+++ b/app/src/main/java/io/github/sustainow/repository/model/SerializableCollectiveAction.kt
@@ -1,6 +1,5 @@
 package io.github.sustainow.repository.model
 
-import android.net.Uri
 import kotlinx.datetime.LocalDate
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -11,14 +10,16 @@ data class SerializableCollectiveAction (
     var images: List<String>?=null,
     val name: String,
     val description: String,
-    @SerialName("user_name")
-    val metadata: SerializableUserMetadata,
+    val metadata: SerializableUserProfile,
     @SerialName("start_date")
     val startDate: LocalDate,
     @SerialName("end_date")
     val endDate: LocalDate,
     val status: String,
+    @SerialName("action_member")
+    val members: List<SerializableUserProfile>
 )
+
 
 @Serializable
 data class SerializableCollectiveActionCreate(
@@ -41,13 +42,5 @@ data class SerializableCollectiveActionUpdate(
     val startDate: LocalDate,
     @SerialName("end_date")
     val endDate: LocalDate,
-)
-
-@Serializable
-data class SerializableUserMetadata(
-    @SerialName("id")
-    val authorId: String,
-    @SerialName("full_name")
-    val authorName: String?
 )
 

--- a/app/src/main/java/io/github/sustainow/repository/model/SerializableCollectiveAction.kt
+++ b/app/src/main/java/io/github/sustainow/repository/model/SerializableCollectiveAction.kt
@@ -10,6 +10,7 @@ data class SerializableCollectiveAction (
     var images: List<String>?=null,
     val name: String,
     val description: String,
+    @SerialName("user_name")
     val metadata: SerializableUserProfile,
     @SerialName("start_date")
     val startDate: LocalDate,
@@ -17,7 +18,17 @@ data class SerializableCollectiveAction (
     val endDate: LocalDate,
     val status: String,
     @SerialName("action_member")
-    val members: List<SerializableUserProfile>
+    val members: List<UserProfileWrapper>
+)
+
+/**
+ * Used for action members where the user profile is nested inside the member information
+ */
+@Serializable
+data class UserProfileWrapper(
+    @SerialName("user_name")
+    val profile:SerializableUserProfile
+
 )
 
 

--- a/app/src/main/java/io/github/sustainow/repository/model/SerializableInvitation.kt
+++ b/app/src/main/java/io/github/sustainow/repository/model/SerializableInvitation.kt
@@ -1,0 +1,20 @@
+package io.github.sustainow.repository.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SerializableInvitation (
+    val id:Int?,
+    @SerialName("user_name")
+    val invitedUser: SerializableUserProfile,
+    @SerialName("action")
+    val action: SerializableCollectiveActionBaseInfo,
+    val accepted: Boolean?
+)
+
+@Serializable
+data class SerializableCollectiveActionBaseInfo(
+    val id: Int,
+    val name: String
+)

--- a/app/src/main/java/io/github/sustainow/repository/model/SerializableInvitation.kt
+++ b/app/src/main/java/io/github/sustainow/repository/model/SerializableInvitation.kt
@@ -18,3 +18,11 @@ data class SerializableCollectiveActionBaseInfo(
     val id: Int,
     val name: String
 )
+
+@Serializable
+data class SerializableInvitationCreate(
+    @SerialName("action_id")
+    val actionId: Int,
+    @SerialName("invited_id")
+    val userId: String
+)

--- a/app/src/main/java/io/github/sustainow/repository/model/SerializableMemberActivity.kt
+++ b/app/src/main/java/io/github/sustainow/repository/model/SerializableMemberActivity.kt
@@ -1,17 +1,24 @@
 package io.github.sustainow.repository.model
 
 import io.github.sustainow.domain.model.ActivityType
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class SerializableMemberActivity (
-    val id:Int?=null,
+    val id:Int,
     @SerialName("action_id")
     val actionId:Int,
+    @SerialName("user_name")
     val member: SerializableUserProfile,
     @SerialName("activity_type")
-    val activityType: ActivityType
+    val activityType: String,
+    val comment: String?,
+    @SerialName("created_at")
+    val date: Instant
 )
 
 @Serializable
@@ -21,5 +28,6 @@ data class SerializableMemberActivityCreate(
     @SerialName("member_id")
     val memberId:String,
     @SerialName("activity_type")
-    val activityType: String
+    val activityType: String,
+    val comment: String? = null
 )

--- a/app/src/main/java/io/github/sustainow/repository/model/SerializableMemberActivity.kt
+++ b/app/src/main/java/io/github/sustainow/repository/model/SerializableMemberActivity.kt
@@ -1,0 +1,25 @@
+package io.github.sustainow.repository.model
+
+import io.github.sustainow.domain.model.ActivityType
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SerializableMemberActivity (
+    val id:Int?=null,
+    @SerialName("action_id")
+    val actionId:Int,
+    val member: SerializableUserProfile,
+    @SerialName("activity_type")
+    val activityType: ActivityType
+)
+
+@Serializable
+data class SerializableMemberActivityCreate(
+    @SerialName("action_id")
+    val actionId:Int,
+    @SerialName("member_id")
+    val memberId:String,
+    @SerialName("activity_type")
+    val activityType: String
+)

--- a/app/src/main/java/io/github/sustainow/repository/model/SerializableUserProfile.kt
+++ b/app/src/main/java/io/github/sustainow/repository/model/SerializableUserProfile.kt
@@ -1,0 +1,17 @@
+package io.github.sustainow.repository.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+
+@Serializable
+@SerialName("user_name")
+data class SerializableUserProfile(
+    @SerialName("id")
+    val id: String,
+    @SerialName("full_name")
+    val name: String,
+    @SerialName("profile_picture")
+    val profilePicture: String? = null
+)
+

--- a/app/src/main/java/io/github/sustainow/service/auth/AuthService.kt
+++ b/app/src/main/java/io/github/sustainow/service/auth/AuthService.kt
@@ -1,5 +1,6 @@
 package io.github.sustainow.service.auth
 
+import io.github.sustainow.domain.model.UserProfile
 import io.github.sustainow.domain.model.UserState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -29,6 +30,11 @@ abstract class AuthService {
      * Sign out the current user.
      */
     abstract suspend fun signOut()
+
+    /**
+     * Get all users profiles, except the current user.
+     */
+    abstract suspend fun listUsers(): List<UserProfile>
 
     /**
      * Check if a user is logged in.

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -107,5 +107,7 @@
     <string name="activity_comment_title"><b>%1$s comentou</b></string>
     <string name="activity_joined_title"><b>%1$s se juntou à ação</b></string>
     <string name="activity_changed_status_title"><b>%1$s atualizou o status da ação</b></string>
+    <string name="create_collective_action_invitation_title">Convites</string>
+    <string name="create_collective_action_invitation_description">Convide outros usuários para te ajudarem nessa ação coletiva</string>
 
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -104,5 +104,8 @@
     <string name="view_collective_action_description_header">Descrição</string>
     <string name="invitation_card_title">Você foi convidado para se juntar à ação <b>%1$s</b></string>
     <string name="view_collective_action_activity_title">Atividades</string>
+    <string name="activity_comment_title"><b>%1$s comentou</b></string>
+    <string name="activity_joined_title"><b>%1$s se juntou à ação</b></string>
+    <string name="activity_changed_status_title"><b>%1$s atualizou o status da ação</b></string>
 
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -102,5 +102,7 @@
     <string name="view_collective_action_back_text">Voltar</string>
     <string name="view_collective_action_author_text">Criada por:</string>
     <string name="view_collective_action_description_header">Descrição</string>
+    <string name="invitation_card_title">Você foi convidado para se juntar à ação <b>%1$s</b></string>
+    <string name="view_collective_action_activity_title">Atividades</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -104,4 +104,7 @@
     <string name="view_collective_action_description_header">Description</string>
     <string name="invitation_card_title">You were invited to join the action %1$s</string>
     <string name="view_collective_action_activity_title">Activities</string>
+    <string name="activity_comment_title"><b>%1$s commented</b></string>
+    <string name="activity_joined_title"><b>%1$s joined the action</b></string>
+    <string name="activity_changed_status_title"><b>%1$s updated the action status</b></string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,4 +107,6 @@
     <string name="activity_comment_title"><b>%1$s commented</b></string>
     <string name="activity_joined_title"><b>%1$s joined the action</b></string>
     <string name="activity_changed_status_title"><b>%1$s updated the action status</b></string>
+    <string name="create_collective_action_invitation_title">Invites</string>
+    <string name="create_collective_action_invitation_description">Invite other users to collaborate with you on this action</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,4 +102,6 @@
     <string name="view_collective_action_back_text">Go back</string>
     <string name="view_collective_action_author_text">Created by:</string>
     <string name="view_collective_action_description_header">Description</string>
+    <string name="invitation_card_title">You were invited to join the action %1$s</string>
+    <string name="view_collective_action_activity_title">Activities</string>
 </resources>


### PR DESCRIPTION
Adding collective actions member invitation and comments

- Users can now be invited on the create and update screens, an user can only be invited if there's no pending invitation for the same action, and if it is not a member already
- Members can comment on the actions they are part, and delete their own comments. Authors can also delete other members comments
- Invitations for an user appear on the search screen, when accepted the user is included as a member of the action 